### PR TITLE
Update nokogiri from 1.6.1. to 1.8.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: ruby
 rvm:
-  - "2.0.0"
+  - "2.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,9 +3,9 @@ GEM
   specs:
     diff-lcs (1.2.5)
     kramdown (1.3.3)
-    mini_portile (0.5.3)
-    nokogiri (1.6.1)
-      mini_portile (~> 0.5.0)
+    mini_portile2 (2.3.0)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     rake (10.3.1)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
@@ -24,3 +24,6 @@ DEPENDENCIES
   nokogiri
   rake
   rspec
+
+BUNDLED WITH
+   1.16.1


### PR DESCRIPTION
- Update nokogiri to 1.8.2
- Update ruby to 2.1.0 in Travis CI
- To fix this warning:

[![https://gyazo.com/9880e631e397e4fbee8b7a0b77f18ae4](https://i.gyazo.com/9880e631e397e4fbee8b7a0b77f18ae4.png)](https://gyazo.com/9880e631e397e4fbee8b7a0b77f18ae4)